### PR TITLE
Convert entry point to TypeScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
   <body class="min-h-screen bg-slate-100">
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import MindMapApp from './GPT_MindMap';
 
-export default function App() {
+export default function App(): JSX.Element {
   return <MindMapApp />;
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App.jsx';
-
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element with id "root" was not found in the document.');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);


### PR DESCRIPTION
## Summary
- convert the Vite entry files to TypeScript so JSX always parses
- add a runtime guard when mounting the React root element
- point index.html at the new TypeScript entry file

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e0fc35c32c832490aa8d54705e1f10